### PR TITLE
Added Laravel 11.0 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^8.0.0|^9.0.0|^10.0.0",
+        "laravel/framework": "^8.0.0|^9.0.0|^10.0.0|^11.0.0",
         "backpack/crud": "^5.0|^6.0"
     },
     "keywords": [


### PR DESCRIPTION
This pull request adds support for Laravel 11.x by updating the composer.json file. The following change was made:

- Updated the require section to include Laravel 11.x
`"laravel/framework": "^8.0.0|^9.0.0|^10.0.0|^11.0.0",`

**Why is this necessary?**

To ensure compatibility with the latest Laravel version.
To allow users of this package to upgrade to Laravel 11 without issues.

**Additional Notes:**

No breaking changes were introduced.
Please review and merge to provide Laravel 11 support for users.
Thank you for considering this update!
